### PR TITLE
Team Scoreboard by Round

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Scoreboard from "./pages/Scoreboard/Scoreboard";
 import StatusScoreboard from "./pages/Scoreboard/Status";
 import StatusRoundScoreboard from "./pages/Scoreboard/StatusRound";
 import TeamScoreboard from "./pages/Scoreboard/Team";
+import TeamRoundScoreboard from "./pages/Scoreboard/TeamRound";
 import { useSystemTheme } from "./themes/Preference";
 
 const LazyComponent = ({
@@ -62,8 +63,16 @@ export default function App() {
           element: <LazyComponent element={<Scoreboard />} />,
         },
         {
+          path: "scoreboard/round/:round",
+          element: <LazyComponent element={<RoundScoreboard />} />,
+        },
+        {
           path: "scoreboard/team/:team",
           element: <LazyComponent element={<TeamScoreboard />} />,
+        },
+        {
+          path: "scoreboard/team/:team/:round",
+          element: <LazyComponent element={<TeamRoundScoreboard />} />,
         },
         {
           path: "scoreboard/check/:check",
@@ -72,10 +81,6 @@ export default function App() {
         {
           path: "scoreboard/check/:check/:round",
           element: <LazyComponent element={<CheckRoundScoreboard />} />,
-        },
-        {
-          path: "scoreboard/round/:round",
-          element: <LazyComponent element={<RoundScoreboard />} />,
         },
         {
           path: "scoreboard/status/:team/:check",
@@ -96,16 +101,20 @@ export default function App() {
           element: <LazyComponent element={<Scoreboard />} />,
         },
         {
+          path: "scoreboard/round/:round",
+          element: <LazyComponent element={<RoundScoreboard />} />,
+        },
+        {
           path: "scoreboard/team/:team",
           element: <LazyComponent element={<TeamScoreboard />} />,
         },
         {
-          path: "scoreboard/check/:check",
-          element: <LazyComponent element={<CheckScoreboard />} />,
+          path: "scoreboard/team/:team/:round",
+          element: <LazyComponent element={<TeamRoundScoreboard />} />,
         },
         {
-          path: "scoreboard/round/:round",
-          element: <LazyComponent element={<RoundScoreboard />} />,
+          path: "scoreboard/check/:check",
+          element: <LazyComponent element={<CheckScoreboard />} />,
         },
         {
           path: "scoreboard/status/:team/:check",

--- a/frontend/src/components/Scoreboard/CheckRound.tsx
+++ b/frontend/src/components/Scoreboard/CheckRound.tsx
@@ -264,7 +264,9 @@ export default function CheckRoundScoreboardComponent({ check, round }: props) {
                     setHighlightedTeam(null);
                   }}
                   onClick={() => {
-                    window.location.href = "/scoreboard/team/" + (index + 1);
+                    window.location.href = `/scoreboard/team/${
+                      index + 1
+                    }/${round}`;
                   }}
                 >
                   {team.name}

--- a/frontend/src/components/Scoreboard/Round.tsx
+++ b/frontend/src/components/Scoreboard/Round.tsx
@@ -236,7 +236,9 @@ export default function RoundScoreboardComponent({ round }: props) {
                       highlightedTeam === team + 1 ? "#343434" : "transparent",
                   }}
                   onClick={() => {
-                    window.location.href = "/scoreboard/team/" + (team + 1);
+                    window.location.href = `/scoreboard/team/${
+                      team + 1
+                    }/${round}`;
                   }}
                 >
                   <Typography variant='subtitle2'>{team + 1}</Typography>

--- a/frontend/src/components/Scoreboard/Status.tsx
+++ b/frontend/src/components/Scoreboard/Status.tsx
@@ -1,3 +1,5 @@
+import ArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import DoubleArrowLeftIcon from "@mui/icons-material/KeyboardDoubleArrowLeft";
 import {
   Box,
   Paper,
@@ -11,8 +13,6 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { StatusScoreboard } from "../../models/Scoreboard/Status";
-import ArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
-import DoubleArrowLeftIcon from "@mui/icons-material/KeyboardDoubleArrowLeft";
 
 type props = {
   check: string;

--- a/frontend/src/components/Scoreboard/Team.tsx
+++ b/frontend/src/components/Scoreboard/Team.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from "react";
 import { TeamScoreboard } from "../../models/Scoreboard/Team";
 
 type props = {
-  team: number;
+  team: string;
 };
 
 export default function TeamScoreboardComponent({ team }: props) {

--- a/frontend/src/components/Scoreboard/Team.tsx
+++ b/frontend/src/components/Scoreboard/Team.tsx
@@ -1,3 +1,5 @@
+import ArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import DoubleArrowLeftIcon from "@mui/icons-material/KeyboardDoubleArrowLeft";
 import {
   Box,
   Paper,
@@ -93,9 +95,52 @@ export default function TeamScoreboardComponent({ team }: props) {
       >
         Team {team}
       </Typography>
-      <Typography component='h1' variant='h5'>
-        Round {data?.round}
-      </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {data && data.round >= 10 && (
+          <DoubleArrowLeftIcon
+            sx={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              window.location.href = `/scoreboard/team/${team}/${
+                data.round - 10
+              }`;
+            }}
+          />
+        )}
+        {data && data.round >= 1 && (
+          <ArrowLeftIcon
+            sx={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              window.location.href = `/scoreboard/team/${team}/${
+                data.round - 1
+              }`;
+            }}
+          />
+        )}
+        {data && (
+          <Typography component='h1' variant='h5'>
+            Round {data.round}
+          </Typography>
+        )}
+        <ArrowLeftIcon
+          sx={{
+            visibility: "hidden",
+          }}
+        />
+        <ArrowLeftIcon
+          sx={{
+            visibility: "hidden",
+          }}
+        />
+      </Box>
       <Box m={2}></Box>
       <TableContainer component={Paper} sx={{ width: "80%" }}>
         <Table>

--- a/frontend/src/components/Scoreboard/TeamRound.tsx
+++ b/frontend/src/components/Scoreboard/TeamRound.tsx
@@ -13,6 +13,10 @@ import { enqueueSnackbar } from "notistack";
 import { useEffect, useState } from "react";
 import { TeamScoreboard } from "../../models/Scoreboard/Team";
 import { Round } from "../../models/ent";
+import ArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import ArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import DoubleArrowLeftIcon from "@mui/icons-material/KeyboardDoubleArrowLeft";
+import DoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArrowRight";
 
 type props = {
   team: string;
@@ -55,7 +59,7 @@ export default function TeamRoundScoreboardComponent({ team, round }: props) {
 
   useEffect(() => {
     const fetchData = async () => {
-      fetch(`http://localhost:8080/api/scoreboard/team/${team}`, {
+      fetch(`http://localhost:8080/api/scoreboard/team/${team}/${round}`, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -126,9 +130,94 @@ export default function TeamRoundScoreboardComponent({ team, round }: props) {
       >
         Team {team}
       </Typography>
-      <Typography component='h1' variant='h5'>
-        Round {data?.round}
-      </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {parseInt(round) > 10 ? (
+          <DoubleArrowLeftIcon
+            sx={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              window.location.href = `/scoreboard/team/${team}/${
+                parseInt(round) - 10
+              }`;
+            }}
+          />
+        ) : (
+          <ArrowLeftIcon
+            sx={{
+              visibility: "hidden",
+            }}
+          />
+        )}
+        {parseInt(round) > 1 ? (
+          <ArrowLeftIcon
+            sx={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              window.location.href = `/scoreboard/team/${team}/${
+                parseInt(round) - 1
+              }`;
+            }}
+          />
+        ) : (
+          <ArrowLeftIcon
+            sx={{
+              visibility: "hidden",
+            }}
+          />
+        )}
+        <Typography
+          component='h1'
+          variant='h5'
+          onClick={() => {
+            window.location.href = `/scoreboard/team/${team}`;
+          }}
+        >
+          Round {round}
+        </Typography>
+        {latestRound && parseInt(round) < latestRound?.number ? (
+          <ArrowRightIcon
+            sx={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              window.location.href = `/scoreboard/team/${team}/${
+                parseInt(round) + 1
+              }`;
+            }}
+          />
+        ) : (
+          <ArrowLeftIcon
+            sx={{
+              visibility: "hidden",
+            }}
+          />
+        )}
+        {latestRound && parseInt(round) + 10 <= latestRound?.number ? (
+          <DoubleArrowRightIcon
+            sx={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              window.location.href = `/scoreboard/team/${team}/${
+                parseInt(round) + 10
+              }`;
+            }}
+          />
+        ) : (
+          <ArrowLeftIcon
+            sx={{
+              visibility: "hidden",
+            }}
+          />
+        )}
+      </Box>
       <Box m={2}></Box>
       <TableContainer component={Paper} sx={{ width: "80%" }}>
         <Table>

--- a/frontend/src/components/Scoreboard/TeamRound.tsx
+++ b/frontend/src/components/Scoreboard/TeamRound.tsx
@@ -1,0 +1,218 @@
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { enqueueSnackbar } from "notistack";
+import { useEffect, useState } from "react";
+import { TeamScoreboard } from "../../models/Scoreboard/Team";
+import { Round } from "../../models/ent";
+
+type props = {
+  team: string;
+  round: string;
+};
+
+export default function TeamRoundScoreboardComponent({ team, round }: props) {
+  const [data, setData] = useState<TeamScoreboard>();
+  const [latestRound, setLatestRound] = useState<Round>();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      fetch(`http://localhost:8080/api/round/latest`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then(async (res) => {
+          if (res.status === 200) {
+            let response = (await res.json()) as Round;
+
+            setLatestRound(response);
+
+            if (0 >= parseInt(round) || parseInt(round) >= response.number) {
+              window.location.href = `/scoreboard/team/${team}`;
+            }
+          } else {
+            enqueueSnackbar("Encountered an error", { variant: "error" });
+          }
+        })
+        .catch((err) => {
+          enqueueSnackbar("Encountered an error: " + err, { variant: "error" });
+          console.log(err);
+        });
+    };
+
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      fetch(`http://localhost:8080/api/scoreboard/team/${team}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then(async (res) => {
+          let response = (await res.json()) as TeamScoreboard;
+          if (res.status === 200) {
+            setData(response);
+          } else {
+            enqueueSnackbar("Encountered an error", { variant: "error" });
+          }
+        })
+        .catch((err) => {
+          enqueueSnackbar("Encountered an error: " + err, { variant: "error" });
+          console.log(err);
+        });
+    };
+
+    fetchData();
+
+    const pollingInterval = setInterval(fetchData, 5000);
+
+    console.log(data);
+    return () => clearInterval(pollingInterval);
+  }, []);
+
+  const [highlightedRound, setHighlightedRound] = useState<number | null>(null);
+  const [highlightedCheck, setHighlightedCheck] = useState<string | null>(null);
+
+  const getBackgroundColor = (status: number, round: number, check: string) => {
+    if (highlightedCheck === null && highlightedRound === null) {
+      if (status === 0) {
+        return "#f44336";
+      } else if (status === 1) {
+        return "#4caf50";
+      }
+      return "#999891";
+    }
+    if (highlightedCheck === check || highlightedRound === round) {
+      if (status === 0) {
+        return "#f44336";
+      } else if (status === 1) {
+        return "#4caf50";
+      }
+      return "#999891";
+    }
+    if (status === 0) {
+      return "#f26359";
+    } else if (status === 1) {
+      return "#75ad77";
+    }
+    return "#cecdc6";
+  };
+
+  return (
+    <>
+      <Typography
+        component='h1'
+        variant='h3'
+        fontWeight={700}
+        sx={{
+          marginTop: 5,
+        }}
+        onClick={() => {
+          window.location.href = "/scoreboard";
+        }}
+      >
+        Team {team}
+      </Typography>
+      <Typography component='h1' variant='h5'>
+        Round {data?.round}
+      </Typography>
+      <Box m={2}></Box>
+      <TableContainer component={Paper} sx={{ width: "80%" }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell size='small'>Round</TableCell>
+              {data?.checks[0].status.map((_, index) => (
+                <TableCell
+                  size='small'
+                  key={"round-" + (data?.round - index)}
+                  sx={{
+                    backgroundColor:
+                      highlightedRound === index ? "#343434" : "transparent",
+                  }}
+                  onMouseEnter={() => {
+                    setHighlightedRound(index);
+                  }}
+                  onMouseLeave={() => {
+                    setHighlightedRound(null);
+                  }}
+                  onClick={() => {
+                    window.location.href =
+                      "/scoreboard/round/" + (data?.round - index);
+                  }}
+                >
+                  {data?.round - index}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data?.checks.map((check, index) => (
+              <TableRow key={index}>
+                <TableCell
+                  size='small'
+                  sx={{
+                    backgroundColor:
+                      highlightedCheck === check.name
+                        ? "#343434"
+                        : "transparent",
+                  }}
+                  onMouseEnter={() => {
+                    setHighlightedCheck(check.name);
+                  }}
+                  onMouseLeave={() => {
+                    setHighlightedCheck(null);
+                  }}
+                  onClick={() => {
+                    window.location.href = `/scoreboard/check/${check.name}`;
+                  }}
+                >
+                  {check.name}
+                </TableCell>
+                {check.status.map((status, index) => (
+                  <TableCell
+                    key={index}
+                    size='small'
+                    sx={{
+                      backgroundColor: getBackgroundColor(
+                        status,
+                        index,
+                        check.name
+                      ),
+                    }}
+                    onMouseEnter={() => {
+                      setHighlightedRound(index);
+                      setHighlightedCheck(check.name);
+                    }}
+                    onMouseLeave={() => {
+                      setHighlightedRound(null);
+                      setHighlightedCheck(null);
+                    }}
+                    onClick={() => {
+                      window.location.href = `/scoreboard/status/${team}/${
+                        check.name
+                      }/${data?.round - index}`;
+                    }}
+                  ></TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+}

--- a/frontend/src/components/Scoreboard/TeamRound.tsx
+++ b/frontend/src/components/Scoreboard/TeamRound.tsx
@@ -266,7 +266,7 @@ export default function TeamRoundScoreboardComponent({ team, round }: props) {
                     setHighlightedCheck(null);
                   }}
                   onClick={() => {
-                    window.location.href = `/scoreboard/check/${check.name}`;
+                    window.location.href = `/scoreboard/check/${check.name}/${round}`;
                   }}
                 >
                   {check.name}

--- a/frontend/src/pages/Scoreboard/Team.tsx
+++ b/frontend/src/pages/Scoreboard/Team.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import TeamScoreboard from "../../components/Scoreboard/Team";
 
 export default function TeamScoreboardPage() {
-  const { team: team } = useParams() as unknown as { team: number };
+  const { team: team } = useParams() as unknown as { team: string };
 
   return (
     <Box

--- a/frontend/src/pages/Scoreboard/TeamRound.tsx
+++ b/frontend/src/pages/Scoreboard/TeamRound.tsx
@@ -1,0 +1,22 @@
+import { Box } from "@mui/material";
+import { useParams } from "react-router-dom";
+import TeamRoundScoreboard from "../../components/Scoreboard/TeamRound";
+
+export default function TeamRoundScoreboardPage() {
+  const { team: team, round: round } = useParams() as unknown as {
+    team: string;
+    round: string;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+      }}
+    >
+      <TeamRoundScoreboard team={team} round={round} />
+    </Box>
+  );
+}

--- a/pkg/data/scoreboard.go
+++ b/pkg/data/scoreboard.go
@@ -91,13 +91,14 @@ func (*scoreboard_s) team(team_number int, rounds int) (*structs.TeamScoreboard,
 	teamScoreboard.Round = entRound.Number
 
 	for i, configCheck := range config.Checks {
-		teamScoreboard.Checks[i].Name = configCheck.Name
-		teamScoreboard.Checks[i].Status = make([]int, rounds)
 
 		entStatus, err := Status.getAllByCheckAndTeamWithLimit(configCheck.Name, team_number, rounds)
 		if err != nil {
 			return nil, err
 		}
+
+		teamScoreboard.Checks[i].Name = configCheck.Name
+		teamScoreboard.Checks[i].Status = make([]int, len(entStatus))
 
 		for j, entStat := range entStatus {
 			switch entStat.Status {
@@ -128,13 +129,14 @@ func (*scoreboard_s) teamRound(team_number int, round_number int, rounds int) (*
 	teamScoreboard.Round = round_number
 
 	for i, configCheck := range config.Checks {
-		teamScoreboard.Checks[i].Name = configCheck.Name
-		teamScoreboard.Checks[i].Status = make([]int, rounds)
 
 		entStatus, err := Status.getAllByCheckAndTeamFromRoundWithLimit(configCheck.Name, team_number, round_number, rounds)
 		if err != nil {
 			return nil, err
 		}
+
+		teamScoreboard.Checks[i].Name = configCheck.Name
+		teamScoreboard.Checks[i].Status = make([]int, len(entStatus))
 
 		for j, entStat := range entStatus {
 			switch entStat.Status {
@@ -179,13 +181,13 @@ func (*scoreboard_s) check(check_name string, rounds int) (*structs.CheckScorebo
 		output := bytes.NewBuffer([]byte{})
 		teamNameTemplate.Execute(output, struct{ Team int }{Team: i + 1})
 
-		checkScoreboard.Teams[i].Name = output.String()
-		checkScoreboard.Teams[i].Status = make([]int, rounds)
-
 		entStatus, err := Status.getAllByCheckAndTeamWithLimit(check_name, int(i+1), rounds)
 		if err != nil {
 			return nil, err
 		}
+
+		checkScoreboard.Teams[i].Name = output.String()
+		checkScoreboard.Teams[i].Status = make([]int, len(entStatus))
 
 		for j, entStat := range entStatus {
 			switch entStat.Status {
@@ -225,13 +227,13 @@ func (*scoreboard_s) checkRound(check_name string, round_number int, rounds int)
 		output := bytes.NewBuffer([]byte{})
 		teamNameTemplate.Execute(output, struct{ Team int }{Team: i + 1})
 
-		checkScoreboard.Teams[i].Name = output.String()
-		checkScoreboard.Teams[i].Status = make([]int, rounds)
-
 		entStatus, err := Status.getAllByCheckAndTeamFromRoundWithLimit(check_name, int(i+1), round_number, rounds)
 		if err != nil {
 			return nil, err
 		}
+
+		checkScoreboard.Teams[i].Name = output.String()
+		checkScoreboard.Teams[i].Status = make([]int, len(entStatus))
 
 		for j, entStat := range entStatus {
 			switch entStat.Status {

--- a/pkg/web/main.go
+++ b/pkg/web/main.go
@@ -58,10 +58,11 @@ func LoadRoutes() {
 
 	// Scoreboard Endpoints
 	API.GET("/scoreboard", scoreboard.Scoreboard)
+	API.GET("/scoreboard/round/:round", scoreboard.Round)
 	API.GET("/scoreboard/team/:team", scoreboard.Team)
+	API.GET("/scoreboard/team/:team/:round", scoreboard.TeamRound)
 	API.GET("/scoreboard/check/:check", scoreboard.Check)
 	API.GET("/scoreboard/check/:check/:round", scoreboard.CheckRound)
-	API.GET("/scoreboard/round/:round", scoreboard.Round)
 	API.GET("/scoreboard/status/:team/:check", scoreboard.Status)
 	API.GET("/scoreboard/status/:team/:check/:round", scoreboard.StatusRound)
 

--- a/pkg/web/scoreboard/team.go
+++ b/pkg/web/scoreboard/team.go
@@ -23,3 +23,28 @@ func Team(ctx *gin.Context) {
 
 	ctx.JSON(200, teamScoreboard)
 }
+
+func TeamRound(ctx *gin.Context) {
+	teamStr := ctx.Param("team")
+	roundStr := ctx.Param("round")
+
+	team, err := strconv.Atoi(teamStr)
+	if err != nil {
+		ctx.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+
+	round, err := strconv.Atoi(roundStr)
+	if err != nil {
+		ctx.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+
+	teamScoreboard, err := data.Scoreboard.TeamRound(team, round, 10)
+	if err != nil {
+		ctx.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(200, teamScoreboard)
+}

--- a/pkg/web/scoreboard/team.go
+++ b/pkg/web/scoreboard/team.go
@@ -15,7 +15,7 @@ func Team(ctx *gin.Context) {
 		return
 	}
 
-	teamScoreboard, err := data.Scoreboard.Team(team, 10)
+	teamScoreboard, err := data.Scoreboard.Team(team, 15)
 	if err != nil {
 		ctx.JSON(500, gin.H{"error": err.Error()})
 		return
@@ -40,7 +40,7 @@ func TeamRound(ctx *gin.Context) {
 		return
 	}
 
-	teamScoreboard, err := data.Scoreboard.TeamRound(team, round, 10)
+	teamScoreboard, err := data.Scoreboard.TeamRound(team, round, 15)
 	if err != nil {
 		ctx.JSON(500, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
fixed props typing for Team Scoreboard

scoreboard abstraction for team scoreboard by round

Team Scoreboard by Round endpoint

added team round scoreboard to router

modified team scoreboard round amount to 15 from 10

base implementation of TeamRoundScoreboard Component

added TeamRound Page and fixed Team Page team type

added Team Round Scoreboard route

working arrows for Team Round Scoreboard

update link hrefs

added round errors to check scoreboard

covered scoreboard edge case where amount of requested round exist those that exist before request round